### PR TITLE
Create gitignore with mojave_dynamic folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mojave_dynamic


### PR DESCRIPTION
Allows you to checkout the repo directly to ~/Pictures/Wallpaper and copy in the mojave_dynamic folder without the project showing as dirty